### PR TITLE
Roll back to cloudpg 0.22.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ installing this chart prior to installing Galaxy helm.
 
 ## Supported software versions
 
-- Kubernetes 1.27+
+- Kubernetes 1.30+
 - Helm 3.5+
 
 ## Kubernetes cluster
@@ -46,7 +46,7 @@ helm repo update
 2. Install the chart
 
 ```console
-helm install --create-namespace -n "galaxy-deps" galaxy-deps galaxyproject/galaxy-deps
+helm install --create-namespace -n "galaxy-deps" galaxy-deps cloudve/galaxy-deps
 ```
 
 ### Using the chart from GitHub repo
@@ -54,7 +54,7 @@ helm install --create-namespace -n "galaxy-deps" galaxy-deps galaxyproject/galax
 1. Clone this repository:
 
 ```console
-git clone https://github.com/galaxyproject/galaxy-helm.git
+git clone https://github.com/galaxyproject/galaxy-helm-deps.git
 ```
 
 2. Setup the chart

--- a/galaxy-deps/Chart.yaml
+++ b/galaxy-deps/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: galaxy-deps
 type: application
 version: 1.0.0
-appVersion: "24.1.3"
+appVersion: "24.1.4"
 description: Chart containing environmental dependencies needed by Galaxy. Galaxy is an open, web-based platform for accessible, reproducible, and transparent computational biomedical research.
 icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png
 dependencies:
   - name: cloudnative-pg
     repository: https://cloudnative-pg.github.io/charts/
-    version: 0.23.0
+    version: 0.22.1
     condition: postgresql.deploy
     # cannot alias due to: https://github.com/cloudnative-pg/charts/issues/351
     # alias: postgresql


### PR DESCRIPTION
At 0.23.0, kept getting the following error:
```
Error: UPGRADE FAILED: failed to create resource: Internal error occurred: failed calling webhook "mcluster.cnpg.io": failed to call webhook: Post "https://cnpg-webhook-service.galaxy.svc:443/mutate-postgresql-cnpg-io-v1-cluster?timeout=10s": no endpoints available for service "cnpg-webhook-service"
```
