### PR TITLE
Add post-install -upgrade hook to wait for cnpg; bump cnpg version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ galaxy/charts/
 .vscode
 
 Chart.lock
+galaxy-deps/charts/

--- a/galaxy-deps/Chart.yaml
+++ b/galaxy-deps/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.p
 dependencies:
   - name: cloudnative-pg
     repository: https://cloudnative-pg.github.io/charts/
-    version: 0.22.1
+    version: 0.23.0
     condition: postgresql.deploy
     # cannot alias due to: https://github.com/cloudnative-pg/charts/issues/351
     # alias: postgresql

--- a/galaxy-deps/templates/cnpg-wait.yml
+++ b/galaxy-deps/templates/cnpg-wait.yml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}-wait-for-cnpg
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-weight: "1"
+spec:
+  serviceAccountName: {{ .Release.Name }}-cnpg-wait
+  containers:
+    - name: wait
+      image: bitnami/kubectl
+      command:
+        - kubectl
+        - wait
+        - --for=condition=ready
+        - --selector=app.kubernetes.io/name=cloudnative-pg
+        - --timeout=300s
+        - pod
+  restartPolicy: Never
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-cnpg-wait
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-cnpg-wait
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-cnpg-wait
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-cnpg-wait
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-cnpg-wait
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
I could not figure out how to parameterize the cnpg chart to wait for its webhook to be ready (does not look like the webhook  `timeoutSeconds` variable is exposed), but this post-install hook works. Tested with the latest 0.23 version of the chart as well.