### PR TITLE
Remove appVersion field as it doesn't make much sense in this chart

### DIFF
--- a/galaxy-deps/Chart.yaml
+++ b/galaxy-deps/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v2
 name: galaxy-deps
 type: application
 version: 1.0.0
-appVersion: "24.1.4"
 description: Chart containing environmental dependencies needed by Galaxy. Galaxy is an open, web-based platform for accessible, reproducible, and transparent computational biomedical research.
 icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png
 dependencies:


### PR DESCRIPTION
`appVersion` is not a required field and meanwhile it's one step removed from the Galaxy application, which is what was tracking up to now. However, when changes happen in the Galaxy chart, that would necessitate a change here, yet there is no strict need for those version to be in-sync.