### PR TITLE
Use our modified CNPG operator

### DIFF
--- a/galaxy-deps/Chart.yaml
+++ b/galaxy-deps/Chart.yaml
@@ -8,9 +8,8 @@ dependencies:
   - name: cloudnative-pg
     repository: https://cloudnative-pg.github.io/charts/
     version: 0.23.0
-    condition: postgresql.deploy
-    # cannot alias due to: https://github.com/cloudnative-pg/charts/issues/351
-    # alias: postgresql
+    condition: cnpg.deploy
+    alias: cnpg
     tags:
       - deploy-postgres
   - name: csi-s3

--- a/galaxy-deps/values.yaml
+++ b/galaxy-deps/values.yaml
@@ -1,7 +1,13 @@
-postgresql:
+cnpg:
   #- Whether to deploy the postgresl operator.
   #- In general, we recommend installing the operator globally in production.
   deploy: true
+  # nameOverride is set to work around https://github.com/cloudnative-pg/charts/issues/351
+  # See: https://github.com/cloudnative-pg/cloudnative-pg/issues/2466#issuecomment-2775117800
+  nameOverride: cloudnative-pg
+  image:
+    repository: ksuderman/cloudnative-pg
+    tag: "1.25.2"
 
 #- Configuration block if `cvmfs` is used as `refdata.type`
 cvmfs:


### PR DESCRIPTION
Use a customized `cloudnative-pg` Docker image built from our [CNPG fork](https://github.com/ksuderman/cloudnative-pg/tree/main). If our modifications are accepted we can rollback this change.

This PR also sets an alias for the CNPG operator. The alias used is `cnpg` since we are installing the Cloudnative-PG operator and not Postgres.

See: https://github.com/cloudnative-pg/cloudnative-pg/issues/2466#issuecomment-2775117800
