### PR TITLE
Update K3s to v1.35.3 for Gateway API compatibility

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Start k8s locally
         uses: jupyterhub/action-k3s-helm@v3
         with:
-          k3s-version: v1.30.4+k3s1  # releases:  https://github.com/k3s-io/k3s/tags
+          k3s-version: v1.35.3+k3s1  # releases:  https://github.com/k3s-io/k3s/tags
           metrics-enabled: false
           traefik-enabled: false
       - name: Verify function of k8s, kubectl, and helm


### PR DESCRIPTION
Updates Kubernetes from v1.30.4+k3s1 to v1.35.3+k3s1 to support Gateway API CRDs that use CEL validation rules with isIP() function introduced in v1.31.

This resolves the compatibility issue preventing Gateway API CRDs from installing in CI tests.

Related to PR #14.